### PR TITLE
Let metal build be an option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ set(MLX_BUILD_TESTS OFF)
 set(MLX_BUILD_EXAMPLES OFF)
 set(MLX_BUILD_BENCHMARKS "Build benchmarks for mlx" OFF)
 set(MLX_BUILD_PYTHON_BINDINGS OFF)
-set(MLX_BUILD_METAL ON)
 FetchContent_Declare(
   mlx
   GIT_REPOSITORY "https://github.com/ml-explore/mlx.git"


### PR DESCRIPTION
By default will still build with Metal. To build without do something like:

```
cmake .. -DMLX_BUILD_METAL=OFF && make -j
```