### PR TITLE
Expose overwrite_descriptor

### DIFF
--- a/mlx/c/array.cpp
+++ b/mlx/c/array.cpp
@@ -280,3 +280,7 @@ extern "C" const bfloat16_t* mlx_array_data_bfloat16(mlx_array arr) {
   return MLX_CPP_ARRAY(arr).data<bfloat16_t>();
 }
 #endif
+
+extern "C" void mlx_overwrite_descriptor(mlx_array arr, mlx_array other) {
+  return MLX_CPP_ARRAY(arr).overwrite_descriptor(MLX_CPP_ARRAY(other));
+}

--- a/mlx/c/array.h
+++ b/mlx/c/array.h
@@ -247,6 +247,12 @@ const float16_t* mlx_array_data_float16(mlx_array arr);
  */
 const bfloat16_t* mlx_array_data_bfloat16(mlx_array arr);
 #endif
+
+/**
+ * Replaces the array descriptor with that of another array.
+ */
+void mlx_overwrite_descriptor(mlx_array arr, mlx_array other);
+
 /**@}*/
 
 /**


### PR DESCRIPTION
Exposes `overwrite_descriptor` which is useful for implementing things like add assign - used by python as well.