### PR TITLE
Expose stream device and device type

### DIFF
--- a/mlx/c/stream.cpp
+++ b/mlx/c/stream.cpp
@@ -8,6 +8,13 @@
 #include "mlx/c/private/string.h"
 #include "mlx/c/stream.h"
 
+namespace {
+mlx_device_type to_c_device_type(mlx::core::Device::DeviceType type) {
+  static mlx_device_type map[] = {MLX_CPU, MLX_GPU};
+  return map[(int)type];
+}
+} // namespace
+
 mlx_string_* mlx_stream_::tostring() {
   std::ostringstream os;
   os << ctx;
@@ -23,6 +30,12 @@ extern "C" mlx_stream mlx_stream_new_on_device(mlx_device dev) {
 }
 extern "C" bool mlx_stream_equal(mlx_stream lhs, mlx_stream rhs) {
   return lhs->ctx == rhs->ctx;
+}
+extern "C" mlx_device mlx_stream_get_device(mlx_stream stream) {
+  return new mlx_device_(stream->ctx.device);
+}
+extern "C" mlx_device_type mlx_stream_get_device_type(mlx_stream stream) {
+  return to_c_device_type(stream->ctx.device.type);
 }
 extern "C" void mlx_synchronize(mlx_stream stream) {
   mlx::core::synchronize(stream->ctx);

--- a/mlx/c/stream.cpp
+++ b/mlx/c/stream.cpp
@@ -8,13 +8,6 @@
 #include "mlx/c/private/string.h"
 #include "mlx/c/stream.h"
 
-namespace {
-mlx_device_type to_c_device_type(mlx::core::Device::DeviceType type) {
-  static mlx_device_type map[] = {MLX_CPU, MLX_GPU};
-  return map[(int)type];
-}
-} // namespace
-
 mlx_string_* mlx_stream_::tostring() {
   std::ostringstream os;
   os << ctx;
@@ -33,9 +26,6 @@ extern "C" bool mlx_stream_equal(mlx_stream lhs, mlx_stream rhs) {
 }
 extern "C" mlx_device mlx_stream_get_device(mlx_stream stream) {
   return new mlx_device_(stream->ctx.device);
-}
-extern "C" mlx_device_type mlx_stream_get_device_type(mlx_stream stream) {
-  return to_c_device_type(stream->ctx.device.type);
 }
 extern "C" void mlx_synchronize(mlx_stream stream) {
   mlx::core::synchronize(stream->ctx);

--- a/mlx/c/stream.h
+++ b/mlx/c/stream.h
@@ -39,10 +39,6 @@ bool mlx_stream_equal(mlx_stream lhs, mlx_stream rhs);
  */
 mlx_device mlx_stream_get_device(mlx_stream stream);
 /**
- * Return the device type of the stream.
- */
-mlx_device_type mlx_stream_get_device_type(mlx_stream stream);
-/**
  * Synchronize with the provided stream.
  */
 void mlx_synchronize(mlx_stream stream);

--- a/mlx/c/stream.h
+++ b/mlx/c/stream.h
@@ -35,6 +35,14 @@ mlx_stream mlx_stream_new_on_device(mlx_device dev);
  */
 bool mlx_stream_equal(mlx_stream lhs, mlx_stream rhs);
 /**
+ * Return the device of the stream.
+ */
+mlx_device mlx_stream_get_device(mlx_stream stream);
+/**
+ * Return the device type of the stream.
+ */
+mlx_device_type mlx_stream_get_device_type(mlx_stream stream);
+/**
  * Synchronize with the provided stream.
  */
 void mlx_synchronize(mlx_stream stream);
@@ -50,6 +58,7 @@ mlx_stream mlx_set_default_stream(mlx_stream stream);
  * Returns the current default CPU stream.
  */
 mlx_stream mlx_cpu_stream();
+
 /**
  * Returns the current default GPU stream.
  */


### PR DESCRIPTION
Added one "methods" to the stream class:

- `mlx_stream_get_device` returns a `mlx_device` on the heap

Closes #25 