### PR TITLE
Allow creating fallible closure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ set(mlxc-src
     ${CMAKE_CURRENT_LIST_DIR}/mlx/c/object.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/c/ops.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/c/random.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/mlx/c/result.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/c/stream.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/c/string.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/c/transforms.cpp

--- a/mlx/c/closure.h
+++ b/mlx/c/closure.h
@@ -4,6 +4,7 @@
 #define MLX_CLOSURE_H
 
 #include "mlx/c/array.h"
+#include "mlx/c/result.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,6 +60,11 @@ mlx_vector_vector_array mlx_closure_value_and_grad_apply(
     const mlx_vector_array inputs);
 
 /**@}*/
+
+mlx_closure mlx_fallible_closure_new_with_payload(
+    mlx_vector_array_result (*fun)(const mlx_vector_array, void*),
+    void* payload,
+    void (*dtor)(void*));
 
 #ifdef __cplusplus
 }

--- a/mlx/c/result.cpp
+++ b/mlx/c/result.cpp
@@ -1,0 +1,35 @@
+#include "mlx/c/result.h"
+
+extern "C" mlx_vector_array_result mlx_vector_array_result_new_ok(mlx_vector_array ok) {
+  mlx_vector_array_result result;
+  result.tag = mlx_result_tag_ok;
+  result.ok = ok;
+  return result;
+}
+
+extern "C" mlx_vector_array_result mlx_vector_array_result_new_err(mlx_string err) {
+  mlx_vector_array_result result;
+  result.tag = mlx_result_tag_err;
+  result.err = err;
+  return result;
+}
+
+extern "C" bool mlx_vector_array_result_is_ok(mlx_vector_array_result *result) {
+  return result->tag == mlx_result_tag_ok;
+}
+
+extern "C" bool mlx_vector_array_result_is_err(mlx_vector_array_result *result) {
+  return result->tag == mlx_result_tag_err;
+}
+
+extern "C" mlx_result_tag mlx_vector_array_result_get_tag(mlx_vector_array_result *result) {
+  return result->tag;
+}
+
+mlx_vector_array mlx_vector_array_result_into_ok(mlx_vector_array_result result) {
+  return result.ok;
+}
+
+extern "C" mlx_string mlx_vector_array_result_into_err(mlx_vector_array_result result) {
+  return result.err;
+}

--- a/mlx/c/result.h
+++ b/mlx/c/result.h
@@ -1,0 +1,38 @@
+#ifndef MLX_RESULT_H
+#define MLX_RESULT_H
+
+#include "mlx/c/array.h"
+#include "mlx/c/string.h"
+
+#ifdef __cplusplus
+#include <stdexcept>
+
+extern "C" {
+#endif
+
+typedef enum {
+    mlx_result_tag_ok,
+    mlx_result_tag_err,
+} mlx_result_tag;
+
+typedef struct {
+    mlx_result_tag tag;
+    union {
+        mlx_vector_array ok;
+        mlx_string err;
+    };
+} mlx_vector_array_result;
+
+mlx_vector_array_result mlx_vector_array_result_new_ok(mlx_vector_array ok);
+mlx_vector_array_result mlx_vector_array_result_new_err(mlx_string err);
+mlx_result_tag mlx_vector_array_result_get_tag(mlx_vector_array_result *result);
+bool mlx_vector_array_result_is_ok(mlx_vector_array_result *result);
+bool mlx_vector_array_result_is_err(mlx_vector_array_result *result);
+mlx_vector_array mlx_vector_array_result_into_ok(mlx_vector_array_result result);
+mlx_string mlx_vector_array_result_into_err(mlx_vector_array_result result);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This is an experimental attempt at solving #34. There are two major changes

1. Introduce a new type `mlx_vector_array_result` (and corresponding constructor, getter functions) to indicate status of closure execution
2. Introduce a new function `mlx_fallible_closure_new_with_payload()` which takes a fallible closure that returns a `mlx_vector_array_result`, and the inner lambda throws an exception if the closure returns an error