### PR TITLE
Expose DType size through the C api

### DIFF
--- a/mlx/c/array.cpp
+++ b/mlx/c/array.cpp
@@ -30,6 +30,10 @@ extern "C" int mlx_array_free(mlx_array arr) {
   return 0;
 }
 
+extern "C" size_t mlx_array_dtype_size(mlx_array_dtype dtype) {
+  return MLX_CPP_ARRAY_DTYPE(dtype).size();
+}
+
 extern "C" mlx_array mlx_array_new() {
   try {
     return mlx_array_();

--- a/mlx/c/array.cpp
+++ b/mlx/c/array.cpp
@@ -7,6 +7,10 @@
 #include "mlx/c/private/mlx.h"
 #include "mlx/c/string.h"
 
+extern "C" size_t mlx_dtype_size(mlx_dtype dtype) {
+  return mlx_dtype_to_cpp(dtype).size();
+}
+
 extern "C" int mlx_array_tostring(mlx_string* str_, const mlx_array arr) {
   try {
     std::ostringstream os;
@@ -28,10 +32,6 @@ extern "C" int mlx_array_free(mlx_array arr) {
     return 1;
   }
   return 0;
-}
-
-extern "C" size_t mlx_array_dtype_size(mlx_array_dtype dtype) {
-  return MLX_CPP_ARRAY_DTYPE(dtype).size();
 }
 
 extern "C" mlx_array mlx_array_new() {

--- a/mlx/c/array.h
+++ b/mlx/c/array.h
@@ -128,6 +128,11 @@ int mlx_array_set_data(
     mlx_dtype dtype);
 
 /**
+ * The size of one element of the given datatype in bytes.
+ */
+size_t mlx_array_dtype_size(mlx_array_dtype dtype);
+
+/**
  * The size of the array's datatype in bytes.
  */
 size_t mlx_array_itemsize(const mlx_array arr);

--- a/mlx/c/array.h
+++ b/mlx/c/array.h
@@ -50,6 +50,11 @@ typedef enum mlx_dtype_ {
 } mlx_dtype;
 
 /**
+ * Size of given mlx_dtype datatype in bytes.
+ */
+size_t mlx_dtype_size(mlx_dtype dtype);
+
+/**
  * Get array description.
  */
 int mlx_array_tostring(mlx_string* str, const mlx_array arr);
@@ -126,11 +131,6 @@ int mlx_array_set_data(
     const int* shape,
     int dim,
     mlx_dtype dtype);
-
-/**
- * The size of one element of the given datatype in bytes.
- */
-size_t mlx_array_dtype_size(mlx_array_dtype dtype);
 
 /**
  * The size of the array's datatype in bytes.


### PR DESCRIPTION
This PR exposes `DType::size()` through the C API, via a new function : `mlx_array_dtype_size` 
Currently, the only way to do this is by using `mlx_array_itemsize(mlx_array arr)` on an existing array. 