### PR TITLE
CMake: Build with dlfcn-win32 to have dlopen etc. on win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,12 @@ else()
   FetchContent_MakeAvailable(mlx)
 endif()
 
+if(WIN32)
+   find_package(dlfcn-win32 REQUIRED)
+   message(STATUS "dlfcn-win32 lib " ${dlfcn-win32_LIBRARIES})
+   message(STATUS "dlfcn-win32 include " ${dlfcn-win32_INCLUDE_DIRS})
+endif()
+
 # ----------------------------- lib -----------------------------
 
 set(mlxc-src


### PR DESCRIPTION
Similar to https://github.com/ml-explore/mlx/pull/1628