### PR TITLE
Exposed array flags

### DIFF
--- a/mlx/c/array.cpp
+++ b/mlx/c/array.cpp
@@ -284,6 +284,31 @@ extern "C" mlx_dtype mlx_array_dtype(const mlx_array arr) {
   }
 }
 
+extern "C" bool mlx_array_contiguous(const mlx_array arr) {
+  try {
+    return mlx_array_get_(arr).flags().contiguous;
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return false; // DEBUG: could have a specific value
+  }
+}
+extern "C" bool mlx_array_row_contiguous(const mlx_array arr) {
+  try {
+    return mlx_array_get_(arr).flags().row_contiguous;
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return false; // DEBUG: could have a specific value
+  }
+}
+extern "C" bool mlx_array_col_contiguous(const mlx_array arr) {
+  try {
+    return mlx_array_get_(arr).flags().col_contiguous;
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return false; // DEBUG: could have a specific value
+  }
+}
+
 extern "C" int mlx_array_eval(mlx_array arr) {
   try {
     mlx_array_get_(arr).eval();

--- a/mlx/c/array.cpp
+++ b/mlx/c/array.cpp
@@ -284,31 +284,6 @@ extern "C" mlx_dtype mlx_array_dtype(const mlx_array arr) {
   }
 }
 
-extern "C" bool mlx_array_contiguous(const mlx_array arr) {
-  try {
-    return mlx_array_get_(arr).flags().contiguous;
-  } catch (std::exception& e) {
-    mlx_error(e.what());
-    return false; // DEBUG: could have a specific value
-  }
-}
-extern "C" bool mlx_array_row_contiguous(const mlx_array arr) {
-  try {
-    return mlx_array_get_(arr).flags().row_contiguous;
-  } catch (std::exception& e) {
-    mlx_error(e.what());
-    return false; // DEBUG: could have a specific value
-  }
-}
-extern "C" bool mlx_array_col_contiguous(const mlx_array arr) {
-  try {
-    return mlx_array_get_(arr).flags().col_contiguous;
-  } catch (std::exception& e) {
-    mlx_error(e.what());
-    return false; // DEBUG: could have a specific value
-  }
-}
-
 extern "C" int mlx_array_eval(mlx_array arr) {
   try {
     mlx_array_get_(arr).eval();
@@ -561,6 +536,33 @@ extern "C" int _mlx_array_eval_status(
     const mlx_array arr) {
   try {
     *res = mlx_eval_status_to_c(mlx_array_get_(arr).status());
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
+extern "C" int _mlx_array_is_contiguous(bool* res, const mlx_array arr) {
+  try {
+    *res = mlx_array_get_(arr).flags().contiguous;
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
+extern "C" int _mlx_array_is_row_contiguous(bool* res, const mlx_array arr) {
+  try {
+    *res = mlx_array_get_(arr).flags().row_contiguous;
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
+extern "C" int _mlx_array_is_col_contiguous(bool* res, const mlx_array arr) {
+  try {
+    *res = mlx_array_get_(arr).flags().col_contiguous;
   } catch (std::exception& e) {
     mlx_error(e.what());
     return 1;

--- a/mlx/c/array.h
+++ b/mlx/c/array.h
@@ -169,6 +169,19 @@ int mlx_array_dim(const mlx_array arr, int dim);
 mlx_dtype mlx_array_dtype(const mlx_array arr);
 
 /**
+ * Whether the array is contiguous in memory.
+ */
+bool mlx_array_contiguous(const mlx_array arr);
+/**
+ * Whether the array's rows are contiguous in memory.
+ */
+bool mlx_array_row_contiguous(const mlx_array arr);
+/**
+ * Whether the array's columns are contiguous in memory.
+ */
+bool mlx_array_col_contiguous(const mlx_array arr);
+
+/**
  * Evaluate the array.
  */
 int mlx_array_eval(mlx_array arr);

--- a/mlx/c/array.h
+++ b/mlx/c/array.h
@@ -169,19 +169,6 @@ int mlx_array_dim(const mlx_array arr, int dim);
 mlx_dtype mlx_array_dtype(const mlx_array arr);
 
 /**
- * Whether the array is contiguous in memory.
- */
-bool mlx_array_contiguous(const mlx_array arr);
-/**
- * Whether the array's rows are contiguous in memory.
- */
-bool mlx_array_row_contiguous(const mlx_array arr);
-/**
- * Whether the array's columns are contiguous in memory.
- */
-bool mlx_array_col_contiguous(const mlx_array arr);
-
-/**
  * Evaluate the array.
  */
 int mlx_array_eval(mlx_array arr);
@@ -319,7 +306,7 @@ const bfloat16_t* mlx_array_data_bfloat16(const mlx_array arr);
 
 /**
  * Internal array eval status.
- * Use at your own risks.
+ * Use at your own risk.
  */
 typedef enum mlx_eval_status_ {
   MLX_EVAL_STATUS_UNSCHEDULED,
@@ -330,9 +317,24 @@ typedef enum mlx_eval_status_ {
 
 /**
  * Returns array eval status.
- * Internal function: use at your own risks.
+ * Internal function: use at your own risk.
  */
 int _mlx_array_eval_status(mlx_eval_status* res, const mlx_array arr);
+/**
+ * Whether the array is contiguous in memory.
+ * Internal function: use at your own risk.
+ */
+int _mlx_array_is_contiguous(bool* res, const mlx_array arr);
+/**
+ * Whether the array's rows are contiguous in memory.
+ * Internal function: use at your own risk.
+ */
+int _mlx_array_is_row_contiguous(bool* res, const mlx_array arr);
+/**
+ * Whether the array's columns are contiguous in memory.
+ * Internal function: use at your own risk.
+ */
+int _mlx_array_is_col_contiguous(bool* res, const mlx_array arr);
 
 /**@}*/
 


### PR DESCRIPTION
Array flags could be convenient to be able to check - in particular when using the C interface from a system which typically uses column-major ordering such as Julia.