### PR TITLE
Exposed array::wait(), and array::is_available()

### DIFF
--- a/mlx/c/array.cpp
+++ b/mlx/c/array.cpp
@@ -294,26 +294,6 @@ extern "C" int mlx_array_eval(mlx_array arr) {
   return 0;
 }
 
-extern "C" int mlx_array_is_available(bool* res, const mlx_array arr) {
-  try {
-    *res = mlx_array_get_(arr).is_available();
-  } catch (std::exception& e) {
-    mlx_error(e.what());
-    return 1;
-  }
-  return 0;
-}
-
-extern "C" int mlx_array_wait(const mlx_array arr) {
-  try {
-    mlx_array_get_(arr).wait();
-  } catch (std::exception& e) {
-    mlx_error(e.what());
-    return 1;
-  }
-  return 0;
-}
-
 extern "C" int mlx_array_item_bool(bool* res, const mlx_array arr) {
   try {
     *res = mlx_array_get_(arr).item<bool>();
@@ -550,6 +530,26 @@ extern "C" const bfloat16_t* mlx_array_data_bfloat16(const mlx_array arr) {
   }
 }
 #endif
+
+extern "C" int _mlx_array_is_available(bool* res, const mlx_array arr) {
+  try {
+    *res = mlx_array_get_(arr).is_available();
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
+
+extern "C" int _mlx_array_wait(const mlx_array arr) {
+  try {
+    mlx_array_get_(arr).wait();
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
 
 extern "C" int _mlx_array_is_contiguous(bool* res, const mlx_array arr) {
   try {

--- a/mlx/c/array.cpp
+++ b/mlx/c/array.cpp
@@ -551,17 +551,6 @@ extern "C" const bfloat16_t* mlx_array_data_bfloat16(const mlx_array arr) {
 }
 #endif
 
-extern "C" int _mlx_array_eval_status(
-    mlx_eval_status* res,
-    const mlx_array arr) {
-  try {
-    *res = mlx_eval_status_to_c(mlx_array_get_(arr).status());
-  } catch (std::exception& e) {
-    mlx_error(e.what());
-    return 1;
-  }
-  return 0;
-}
 extern "C" int _mlx_array_is_contiguous(bool* res, const mlx_array arr) {
   try {
     *res = mlx_array_get_(arr).flags().contiguous;

--- a/mlx/c/array.cpp
+++ b/mlx/c/array.cpp
@@ -294,6 +294,26 @@ extern "C" int mlx_array_eval(mlx_array arr) {
   return 0;
 }
 
+extern "C" int mlx_array_is_available(bool* res, const mlx_array arr) {
+  try {
+    *res = mlx_array_get_(arr).is_available();
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
+
+extern "C" int mlx_array_wait(const mlx_array arr) {
+  try {
+    mlx_array_get_(arr).wait();
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
+
 extern "C" int mlx_array_item_bool(bool* res, const mlx_array arr) {
   try {
     *res = mlx_array_get_(arr).item<bool>();

--- a/mlx/c/array.h
+++ b/mlx/c/array.h
@@ -315,22 +315,6 @@ const bfloat16_t* mlx_array_data_bfloat16(const mlx_array arr);
 #endif
 
 /**
- * Internal array eval status.
- * Use at your own risk.
- */
-typedef enum mlx_eval_status_ {
-  MLX_EVAL_STATUS_UNSCHEDULED,
-  MLX_EVAL_STATUS_SCHEDULED,
-  MLX_EVAL_STATUS_EVALUATED,
-  MLX_EVAL_STATUS_AVAILABLE,
-} mlx_eval_status;
-
-/**
- * Returns array eval status.
- * Internal function: use at your own risk.
- */
-int _mlx_array_eval_status(mlx_eval_status* res, const mlx_array arr);
-/**
  * Whether the array is contiguous in memory.
  * Internal function: use at your own risk.
  */

--- a/mlx/c/array.h
+++ b/mlx/c/array.h
@@ -174,16 +174,6 @@ mlx_dtype mlx_array_dtype(const mlx_array arr);
 int mlx_array_eval(mlx_array arr);
 
 /**
- * Check if the array is available.
- */
-int mlx_array_is_available(bool* res, const mlx_array arr);
-
-/**
- * Wait on the array to be available. After this `mlx_array_is_available` returns `true`.
- */
-int mlx_array_wait(const mlx_array arr);
-
-/**
  * Access the value of a scalar array.
  */
 int mlx_array_item_bool(bool* res, const mlx_array arr);
@@ -315,15 +305,29 @@ const bfloat16_t* mlx_array_data_bfloat16(const mlx_array arr);
 #endif
 
 /**
+ * Check if the array is available.
+ * Internal function: use at your own risk.
+ */
+int _mlx_array_is_available(bool* res, const mlx_array arr);
+
+/**
+ * Wait on the array to be available. After this `_mlx_array_is_available` returns `true`.
+ * Internal function: use at your own risk.
+ */
+int _mlx_array_wait(const mlx_array arr);
+
+/**
  * Whether the array is contiguous in memory.
  * Internal function: use at your own risk.
  */
 int _mlx_array_is_contiguous(bool* res, const mlx_array arr);
+
 /**
  * Whether the array's rows are contiguous in memory.
  * Internal function: use at your own risk.
  */
 int _mlx_array_is_row_contiguous(bool* res, const mlx_array arr);
+
 /**
  * Whether the array's columns are contiguous in memory.
  * Internal function: use at your own risk.

--- a/mlx/c/array.h
+++ b/mlx/c/array.h
@@ -311,8 +311,8 @@ const bfloat16_t* mlx_array_data_bfloat16(const mlx_array arr);
 int _mlx_array_is_available(bool* res, const mlx_array arr);
 
 /**
- * Wait on the array to be available. After this `_mlx_array_is_available` returns `true`.
- * Internal function: use at your own risk.
+ * Wait on the array to be available. After this `_mlx_array_is_available`
+ * returns `true`. Internal function: use at your own risk.
  */
 int _mlx_array_wait(const mlx_array arr);
 

--- a/mlx/c/array.h
+++ b/mlx/c/array.h
@@ -174,6 +174,16 @@ mlx_dtype mlx_array_dtype(const mlx_array arr);
 int mlx_array_eval(mlx_array arr);
 
 /**
+ * Check if the array is available.
+ */
+int mlx_array_is_available(bool* res, const mlx_array arr);
+
+/**
+ * Wait on the array to be available. After this `mlx_array_is_available` returns `true`.
+ */
+int mlx_array_wait(const mlx_array arr);
+
+/**
  * Access the value of a scalar array.
  */
 int mlx_array_item_bool(bool* res, const mlx_array arr);

--- a/mlx/c/private/enums.h
+++ b/mlx/c/private/enums.h
@@ -69,26 +69,6 @@ mlx::core::Device::DeviceType mlx_device_type_to_cpp(mlx_device_type type) {
       mlx::core::Device::DeviceType::cpu, mlx::core::Device::DeviceType::gpu};
   return map[(int)type];
 }
-
-mlx_eval_status mlx_eval_status_to_c(mlx::core::array::Status type) {
-  static mlx_eval_status map[] = {
-      MLX_EVAL_STATUS_UNSCHEDULED,
-      MLX_EVAL_STATUS_SCHEDULED,
-      MLX_EVAL_STATUS_EVALUATED,
-      MLX_EVAL_STATUS_AVAILABLE,
-  };
-  return map[(int)type];
-}
-mlx::core::array::Status mlx_eval_status_to_cpp(mlx_eval_status type) {
-  static mlx::core::array::Status map[] = {
-      mlx::core::array::Status::unscheduled,
-      mlx::core::array::Status::scheduled,
-      mlx::core::array::Status::evaluated,
-      mlx::core::array::Status::available,
-  };
-  return map[(int)type];
-}
-
 } // namespace
 
 #endif


### PR DESCRIPTION
Follow-up for #51

@awni commented (cf. https://github.com/ml-explore/mlx-c/pull/51#issuecomment-2613227972)
> Does it work for you to simply use `eval` when you are ready to wait on inspecting the array?

In order to integrate the async evaluation of arrays into an event loop like the libuv event loop in Julia, it is preferable to not block the threads servicing the event loop, e.g., by scheduling I/O or other blocking operations (like `wait` or `eval`) to occur on another thread, and then signal a (sleeping) task in the event loop once the blocking operation has completed.

By exposing `mlx_array_wait(arr)`, it is possible to implement the non-blocking behaviour as follows
```julia
# Blocking wait (just a Julia function wrapping the C function)
function mlx_array_wait(arr)
    return ccall((:mlx_array_wait, libmlxc), Cint, (mlx_array,), arr) # function ptr, return type, arg types, args
end

# Non-blocking wait when called via `@threadcall`
function mlx_array_wait_async(arr::mlx_array, condition_handle::Ptr{Nothing})
    wait_result = mlx_array_wait(arr)
    ccall(:uv_async_send, Cint, (Ptr{Nothing}, ), condition_handle) # using libuv to signal the condition given by `condition_handle`
    return wait_result
end

cond = Base.AsyncCondition()

function wait_async(arr::mlx_array)
    mlx_array_wait_async_c = @cfunction(mlx_array_wait_async, Cint, (mlx_array, Ptr{Nothing},)) # C function pointer to `mlx_array_wait_async` for use in `@threadcall`
    @threadcall(mlx_array_wait_async_c, Cint, (Ptr{Nothing},), arr, cond.handle) # Non-blocking call to wait - executes mlx_array_wait_async_c on another thread (not an event loop thread)
end
```

And it would be possible to test it by having `mlx_array_is_available` exposed:
```julia
using Test

wait_async(arr) # Returns immediately
@test !mlx_array_is_available(arr) # `mlx_array_is_available(arr)` should be false - as long as the eval takes a bit of time
wait(cond) # Returns when `mlx_array_wait_async` signals `cond` - it blocks the task, but not the thread running the task
@test mlx_array_is_available(arr) # should be true
eval(arr) # Returns immediately 
```

Julia is using a libuv event loop, like Node.js - hence the similar use of `wait()` from an async callback/thread in the async eval implementation in [node-mlx/src/transforms.cc#L263-L302](https://github.com/frost-beta/node-mlx/blob/fc4b52ec40e0f86abd0457e618065fe0996b89c5/src/transforms.cc#L263-L302).
