### PR TITLE
Allow clearing args in `mlx_fast_metal_kernel`

### DIFF
--- a/mlx/c/fast.cpp
+++ b/mlx/c/fast.cpp
@@ -223,6 +223,19 @@ extern "C" int mlx_fast_metal_kernel_add_template_arg_bool(
   return 0;
 }
 
+extern "C" int mlx_fast_metal_kernel_clear_args(
+    mlx_fast_metal_kernel cls) {
+  try {
+    mlx_fast_metal_kernel_get_(cls).template.clear();
+    mlx_fast_metal_kernel_get_(cls).output_shapes.clear();
+    mlx_fast_metal_kernel_get_(cls).output_dtypes.clear();
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
+
 extern "C" mlx_fast_metal_kernel mlx_fast_metal_kernel_new(
     const char* name,
     const char* source,

--- a/mlx/c/fast.h
+++ b/mlx/c/fast.h
@@ -109,6 +109,8 @@ int mlx_fast_metal_kernel_add_template_arg_bool(
     mlx_fast_metal_kernel cls,
     const char* name,
     bool value);
+int mlx_fast_metal_kernel_clear_args(
+    mlx_fast_metal_kernel cls);
 
 int mlx_fast_metal_kernel_apply(
     mlx_vector_array* outputs,

--- a/python/mlxhooks.py
+++ b/python/mlxhooks.py
@@ -364,6 +364,8 @@ int mlx_fast_metal_kernel_add_template_arg_bool(
     mlx_fast_metal_kernel cls,
     const char* name,
     bool value);
+int mlx_fast_metal_kernel_clear_args(
+    mlx_fast_metal_kernel cls);
 
 int mlx_fast_metal_kernel_apply(
     mlx_vector_array* outputs,


### PR DESCRIPTION
This is required to implement the pattern we use in Python with the C api. See https://github.com/ml-explore/mlx-swift/issues/211

Currently we can't remove output_shape/dtype or template args from the metal kernel object with the C api which means we can't reuse the same metal kernel.

I'll undraft this once is in #61 is in.