### PR TITLE
Added include of stdbool.h

### DIFF
--- a/mlx/c/compile.h
+++ b/mlx/c/compile.h
@@ -6,6 +6,7 @@
 #ifndef MLX_COMPILE_H
 #define MLX_COMPILE_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 

--- a/mlx/c/device.h
+++ b/mlx/c/device.h
@@ -3,6 +3,8 @@
 #ifndef MLX_DEVICE_H
 #define MLX_DEVICE_H
 
+#include <stdbool.h>
+
 #include "mlx/c/string.h"
 
 #ifdef __cplusplus

--- a/mlx/c/distributed.h
+++ b/mlx/c/distributed.h
@@ -6,6 +6,7 @@
 #ifndef MLX_DISTRIBUTED_H
 #define MLX_DISTRIBUTED_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 

--- a/mlx/c/distributed_group.h
+++ b/mlx/c/distributed_group.h
@@ -3,6 +3,8 @@
 #ifndef MLX_DISTRIBUTED_GROUP_H
 #define MLX_DISTRIBUTED_GROUP_H
 
+#include <stdbool.h>
+
 #include "mlx/c/stream.h"
 
 #ifdef __cplusplus

--- a/mlx/c/fast.h
+++ b/mlx/c/fast.h
@@ -6,6 +6,7 @@
 #ifndef MLX_FAST_H
 #define MLX_FAST_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 

--- a/mlx/c/fft.h
+++ b/mlx/c/fft.h
@@ -6,6 +6,7 @@
 #ifndef MLX_FFT_H
 #define MLX_FFT_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 

--- a/mlx/c/io.h
+++ b/mlx/c/io.h
@@ -6,6 +6,7 @@
 #ifndef MLX_IO_H
 #define MLX_IO_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 

--- a/mlx/c/io_types.h
+++ b/mlx/c/io_types.h
@@ -3,6 +3,8 @@
 #ifndef MLX_IO_TYPES_H
 #define MLX_IO_TYPES_H
 
+#include <stdbool.h>
+
 #include "mlx/c/string.h"
 
 #ifdef __cplusplus

--- a/mlx/c/linalg.h
+++ b/mlx/c/linalg.h
@@ -6,6 +6,7 @@
 #ifndef MLX_LINALG_H
 #define MLX_LINALG_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 

--- a/mlx/c/memory.h
+++ b/mlx/c/memory.h
@@ -6,6 +6,7 @@
 #ifndef MLX_MEMORY_H
 #define MLX_MEMORY_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 

--- a/mlx/c/metal.h
+++ b/mlx/c/metal.h
@@ -6,6 +6,7 @@
 #ifndef MLX_METAL_H
 #define MLX_METAL_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 

--- a/mlx/c/ops.h
+++ b/mlx/c/ops.h
@@ -6,6 +6,7 @@
 #ifndef MLX_OPS_H
 #define MLX_OPS_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 

--- a/mlx/c/optional.h
+++ b/mlx/c/optional.h
@@ -3,6 +3,8 @@
 #ifndef MLX_OPTIONAL_H
 #define MLX_OPTIONAL_H
 
+#include <stdbool.h>
+
 #include "mlx/c/array.h"
 #include "mlx/c/string.h"
 

--- a/mlx/c/random.h
+++ b/mlx/c/random.h
@@ -6,6 +6,7 @@
 #ifndef MLX_RANDOM_H
 #define MLX_RANDOM_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 

--- a/mlx/c/transforms.h
+++ b/mlx/c/transforms.h
@@ -6,6 +6,7 @@
 #ifndef MLX_TRANSFORMS_H
 #define MLX_TRANSFORMS_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 

--- a/mlx/c/transforms_impl.h
+++ b/mlx/c/transforms_impl.h
@@ -6,6 +6,7 @@
 #ifndef MLX_TRANSFORMS_IMPL_H
 #define MLX_TRANSFORMS_IMPL_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 

--- a/python/c.py
+++ b/python/c.py
@@ -70,6 +70,7 @@ def generate(funcs, enums, header, headername, implementation, docstring):
         print("#define MLX_" + headername.upper() + "_H")
         print(
             """
+    #include <stdbool.h>
     #include <stdint.h>
     #include <stdio.h>
 


### PR DESCRIPTION
Added include of `stdbool.h` for all headers referencing `bool` (and also for all auto-generated headers).

Notably missing from `mlx/c/device.h` - in comparison to `mlx/c/stream.h`.