### PR TITLE
Add mlx_fast_rope_offset_array for array offset support

### DIFF
--- a/mlx/c/fast.cpp
+++ b/mlx/c/fast.cpp
@@ -571,6 +571,36 @@ extern "C" int mlx_fast_rope(
   }
   return 0;
 }
+extern "C" int mlx_fast_rope_offset_array(
+    mlx_array* res,
+    const mlx_array x,
+    int dims,
+    bool traditional,
+    mlx_optional_float base,
+    float scale,
+    const mlx_array offset,
+    const mlx_array freqs /* may be null */,
+    const mlx_stream s) {
+  try {
+    mlx_array_set_(
+        *res,
+        mlx::core::fast::rope(
+            mlx_array_get_(x),
+            dims,
+            traditional,
+            (base.has_value ? std::make_optional<float>(base.value)
+                            : std::nullopt),
+            scale,
+            mlx_array_get_(offset),
+            (freqs.ctx ? std::make_optional(mlx_array_get_(freqs))
+                       : std::nullopt),
+            mlx_stream_get_(s)));
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
 extern "C" int mlx_fast_scaled_dot_product_attention(
     mlx_array* res,
     const mlx_array queries,

--- a/mlx/c/fast.h
+++ b/mlx/c/fast.h
@@ -176,6 +176,16 @@ int mlx_fast_rope(
     int offset,
     const mlx_array freqs /* may be null */,
     const mlx_stream s);
+int mlx_fast_rope_offset_array(
+    mlx_array* res,
+    const mlx_array x,
+    int dims,
+    bool traditional,
+    mlx_optional_float base,
+    float scale,
+    const mlx_array offset,
+    const mlx_array freqs /* may be null */,
+    const mlx_stream s);
 int mlx_fast_scaled_dot_product_attention(
     mlx_array* res,
     const mlx_array queries,


### PR DESCRIPTION
## Summary

Add `mlx_fast_rope_offset_array()` C binding to expose the array offset overload of `mlx::core::fast::rope`.

## Motivation

The C++ API has two overloads for rope:

```cpp
array rope(..., int offset, ...);
array rope(..., const array& offset, ...);  // Already exists!
```

The C bindings only exposed the int offset version via mlx_fast_rope(). This PR adds mlx_fast_rope_offset_array() to expose the array overload.

This enables use cases like:
-  Continuous batching: Different sequences at different positions
-  Speculative decoding: Verifying candidates at different positions in parallel
-  Sliding window attention: Processing chunks starting at different offsets

## Changes

-  mlx/c/fast.h: Add mlx_fast_rope_offset_array() declaration
-  mlx/c/fast.cpp: Add implementation calling the existing C++ array overload

## Usage

``` c
// Array of offsets for batch
mlx_array offsets = /* [50, 20, 0] */;
mlx_fast_rope_offset_array(&result, x, dims, traditional, base, scale, offsets, freqs, stream);
```

## Context

This update is needed by [mlx-swift](https://github.com/ml-explore/mlx-swift) to match the Python API which already supports array offsets via pybind11's direct C++ access.