### PR TITLE
doc: use modern CMake invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To build, run the following commands:
 
 ```shell
 cmake -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build
+cmake --build build -j
 ```
 
 From the `build/` directory, you can run an [example](examples/example.c)

--- a/docs/src/install.rst
+++ b/docs/src/install.rst
@@ -12,7 +12,7 @@ To build MLX C, run the following commands:
 .. code-block:: shell
 
   cmake -B build -DCMAKE_BUILD_TYPE=Release
-  cmake --build build
+  cmake --build build -j
 
 MLX C will fetch `MLX <https://github.com/ml-explore/mlx>`_ under the hood,
 compile it, and then compile the C API.


### PR DESCRIPTION
Since CMake 3.13 circa year 2018, this is a more compact syntax to build CMake projects.