### PR TITLE
guard mlx_array_dim against 0-dim and out-of-bounds access

### DIFF
--- a/mlx/c/array.cpp
+++ b/mlx/c/array.cpp
@@ -330,7 +330,12 @@ extern "C" const size_t* mlx_array_strides(const mlx_array arr) {
 }
 extern "C" int mlx_array_dim(const mlx_array arr, int dim) {
   try {
-    return mlx_array_get_(arr).shape(dim);
+    auto& a = mlx_array_get_(arr);
+    int ndim = a.ndim();
+    if (ndim == 0) return 1;  // scalar: treat as size 1 for any dim
+    if (dim < 0) dim += ndim;
+    if (dim < 0 || dim >= ndim) return 0;  // out of bounds: return 0 instead of crashing
+    return a.shape(dim);
   } catch (std::exception& e) {
     mlx_error(e.what());
     return 0;


### PR DESCRIPTION
## Proposed changes

`mlx_array_dim` crashes with `SmallVector out of range` when called on
scalar (0-dim) arrays or with `dim >= ndim`. The exception is caught by
`mlx_error` which calls Swift's `fatalError`, killing the process.

This happens during Swift metadata initialization when `Module` subclass
hierarchies trigger lazy evaluation of 0-dimensional arrays. The crash
is non-deterministic and depends on binary layout, making it difficult
to reproduce but fatal when it hits.

Fix: guard against invalid dimensions before accessing `shape()`.
Returns 1 for scalars, 0 for out-of-bounds. No change for valid inputs.

### Repro

Any Swift binary linking `MLXLMCommon` (from `mlx-swift-lm`) with certain
class hierarchies can trigger this at load time:

```
MLX/ErrorHandler.swift:343: Fatal error: SmallVector out of range.
at mlx-c/mlx/c/array.cpp:335
```

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have run `pre-commit run --all-files` to format my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)