### PR TITLE
feat: regenerate bindings for MLX 0.31.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ else()
   FetchContent_Declare(
     mlx
     GIT_REPOSITORY "https://github.com/ml-explore/mlx.git"
-    GIT_TAG v0.31.1)
+    GIT_TAG v0.31.2)
   FetchContent_MakeAvailable(mlx)
 endif()
 

--- a/mlx/c/compile.h
+++ b/mlx/c/compile.h
@@ -34,6 +34,7 @@ typedef enum mlx_compile_mode_ {
   MLX_COMPILE_MODE_NO_FUSE,
   MLX_COMPILE_MODE_ENABLED
 } mlx_compile_mode;
+
 int mlx_compile(mlx_closure* res, const mlx_closure fun, bool shapeless);
 int mlx_detail_compile(
     mlx_closure* res,

--- a/mlx/c/fft.cpp
+++ b/mlx/c/fft.cpp
@@ -13,11 +13,17 @@ extern "C" int mlx_fft_fft(
     const mlx_array a,
     int n,
     int axis,
+    mlx_f_f_t_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
         *res,
-        mlx::core::fft::fft(mlx_array_get_(a), n, axis, mlx_stream_get_(s)));
+        mlx::core::fft::fft(
+            mlx_array_get_(a),
+            n,
+            axis,
+            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
     return 1;
@@ -31,6 +37,7 @@ extern "C" int mlx_fft_fft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -39,7 +46,18 @@ extern "C" int mlx_fft_fft2(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
+            static_cast<mlx::core::fft::FFTNorm>(norm),
             mlx_stream_get_(s)));
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
+extern "C" int
+mlx_fft_fftfreq(mlx_array* res, int n, double d, const mlx_stream s) {
+  try {
+    mlx_array_set_(*res, mlx::core::fft::fftfreq(n, d, mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
     return 1;
@@ -53,6 +71,7 @@ extern "C" int mlx_fft_fftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -61,6 +80,7 @@ extern "C" int mlx_fft_fftn(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
+            static_cast<mlx::core::fft::FFTNorm>(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -92,11 +112,17 @@ extern "C" int mlx_fft_ifft(
     const mlx_array a,
     int n,
     int axis,
+    mlx_f_f_t_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
         *res,
-        mlx::core::fft::ifft(mlx_array_get_(a), n, axis, mlx_stream_get_(s)));
+        mlx::core::fft::ifft(
+            mlx_array_get_(a),
+            n,
+            axis,
+            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
     return 1;
@@ -110,6 +136,7 @@ extern "C" int mlx_fft_ifft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -118,6 +145,7 @@ extern "C" int mlx_fft_ifft2(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
+            static_cast<mlx::core::fft::FFTNorm>(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -132,6 +160,7 @@ extern "C" int mlx_fft_ifftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -140,6 +169,7 @@ extern "C" int mlx_fft_ifftn(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
+            static_cast<mlx::core::fft::FFTNorm>(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -171,11 +201,17 @@ extern "C" int mlx_fft_irfft(
     const mlx_array a,
     int n,
     int axis,
+    mlx_f_f_t_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
         *res,
-        mlx::core::fft::irfft(mlx_array_get_(a), n, axis, mlx_stream_get_(s)));
+        mlx::core::fft::irfft(
+            mlx_array_get_(a),
+            n,
+            axis,
+            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
     return 1;
@@ -189,6 +225,7 @@ extern "C" int mlx_fft_irfft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -197,6 +234,7 @@ extern "C" int mlx_fft_irfft2(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
+            static_cast<mlx::core::fft::FFTNorm>(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -211,6 +249,7 @@ extern "C" int mlx_fft_irfftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -219,6 +258,7 @@ extern "C" int mlx_fft_irfftn(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
+            static_cast<mlx::core::fft::FFTNorm>(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -231,11 +271,17 @@ extern "C" int mlx_fft_rfft(
     const mlx_array a,
     int n,
     int axis,
+    mlx_f_f_t_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
         *res,
-        mlx::core::fft::rfft(mlx_array_get_(a), n, axis, mlx_stream_get_(s)));
+        mlx::core::fft::rfft(
+            mlx_array_get_(a),
+            n,
+            axis,
+            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
     return 1;
@@ -249,6 +295,7 @@ extern "C" int mlx_fft_rfft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -257,7 +304,18 @@ extern "C" int mlx_fft_rfft2(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
+            static_cast<mlx::core::fft::FFTNorm>(norm),
             mlx_stream_get_(s)));
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
+extern "C" int
+mlx_fft_rfftfreq(mlx_array* res, int n, double d, const mlx_stream s) {
+  try {
+    mlx_array_set_(*res, mlx::core::fft::rfftfreq(n, d, mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
     return 1;
@@ -271,6 +329,7 @@ extern "C" int mlx_fft_rfftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -279,6 +338,7 @@ extern "C" int mlx_fft_rfftn(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
+            static_cast<mlx::core::fft::FFTNorm>(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());

--- a/mlx/c/fft.cpp
+++ b/mlx/c/fft.cpp
@@ -13,7 +13,7 @@ extern "C" int mlx_fft_fft(
     const mlx_array a,
     int n,
     int axis,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -22,7 +22,7 @@ extern "C" int mlx_fft_fft(
             mlx_array_get_(a),
             n,
             axis,
-            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_fft_norm_to_cpp(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -37,7 +37,7 @@ extern "C" int mlx_fft_fft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -46,7 +46,7 @@ extern "C" int mlx_fft_fft2(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
-            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_fft_norm_to_cpp(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -71,7 +71,7 @@ extern "C" int mlx_fft_fftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -80,7 +80,7 @@ extern "C" int mlx_fft_fftn(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
-            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_fft_norm_to_cpp(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -112,7 +112,7 @@ extern "C" int mlx_fft_ifft(
     const mlx_array a,
     int n,
     int axis,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -121,7 +121,7 @@ extern "C" int mlx_fft_ifft(
             mlx_array_get_(a),
             n,
             axis,
-            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_fft_norm_to_cpp(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -136,7 +136,7 @@ extern "C" int mlx_fft_ifft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -145,7 +145,7 @@ extern "C" int mlx_fft_ifft2(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
-            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_fft_norm_to_cpp(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -160,7 +160,7 @@ extern "C" int mlx_fft_ifftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -169,7 +169,7 @@ extern "C" int mlx_fft_ifftn(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
-            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_fft_norm_to_cpp(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -201,7 +201,7 @@ extern "C" int mlx_fft_irfft(
     const mlx_array a,
     int n,
     int axis,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -210,7 +210,7 @@ extern "C" int mlx_fft_irfft(
             mlx_array_get_(a),
             n,
             axis,
-            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_fft_norm_to_cpp(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -225,7 +225,7 @@ extern "C" int mlx_fft_irfft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -234,7 +234,7 @@ extern "C" int mlx_fft_irfft2(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
-            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_fft_norm_to_cpp(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -249,7 +249,7 @@ extern "C" int mlx_fft_irfftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -258,7 +258,7 @@ extern "C" int mlx_fft_irfftn(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
-            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_fft_norm_to_cpp(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -271,7 +271,7 @@ extern "C" int mlx_fft_rfft(
     const mlx_array a,
     int n,
     int axis,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -280,7 +280,7 @@ extern "C" int mlx_fft_rfft(
             mlx_array_get_(a),
             n,
             axis,
-            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_fft_norm_to_cpp(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -295,7 +295,7 @@ extern "C" int mlx_fft_rfft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -304,7 +304,7 @@ extern "C" int mlx_fft_rfft2(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
-            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_fft_norm_to_cpp(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());
@@ -329,7 +329,7 @@ extern "C" int mlx_fft_rfftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s) {
   try {
     mlx_array_set_(
@@ -338,7 +338,7 @@ extern "C" int mlx_fft_rfftn(
             mlx_array_get_(a),
             mlx::core::Shape(n, n + n_num),
             std::vector<int>(axes, axes + axes_num),
-            static_cast<mlx::core::fft::FFTNorm>(norm),
+            mlx_fft_norm_to_cpp(norm),
             mlx_stream_get_(s)));
   } catch (std::exception& e) {
     mlx_error(e.what());

--- a/mlx/c/fft.h
+++ b/mlx/c/fft.h
@@ -23,17 +23,23 @@
 extern "C" {
 #endif
 
-typedef enum mlx_f_f_t_norm_ {
-  MLX_F_F_T_NORM_BACKWARD,
-  MLX_F_F_T_NORM_ORTHO,
-  MLX_F_F_T_NORM_FORWARD
-} mlx_f_f_t_norm;
+/**
+ * \defgroup fft FFT operations
+ */
+/**@{*/
+
+typedef enum mlx_fft_norm_ {
+  MLX_FFT_NORM_BACKWARD,
+  MLX_FFT_NORM_ORTHO,
+  MLX_FFT_NORM_FORWARD
+} mlx_fft_norm;
+
 int mlx_fft_fft(
     mlx_array* res,
     const mlx_array a,
     int n,
     int axis,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s);
 int mlx_fft_fft2(
     mlx_array* res,
@@ -42,7 +48,7 @@ int mlx_fft_fft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s);
 int mlx_fft_fftfreq(mlx_array* res, int n, double d, const mlx_stream s);
 int mlx_fft_fftn(
@@ -52,7 +58,7 @@ int mlx_fft_fftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s);
 int mlx_fft_fftshift(
     mlx_array* res,
@@ -65,7 +71,7 @@ int mlx_fft_ifft(
     const mlx_array a,
     int n,
     int axis,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s);
 int mlx_fft_ifft2(
     mlx_array* res,
@@ -74,7 +80,7 @@ int mlx_fft_ifft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s);
 int mlx_fft_ifftn(
     mlx_array* res,
@@ -83,7 +89,7 @@ int mlx_fft_ifftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s);
 int mlx_fft_ifftshift(
     mlx_array* res,
@@ -96,7 +102,7 @@ int mlx_fft_irfft(
     const mlx_array a,
     int n,
     int axis,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s);
 int mlx_fft_irfft2(
     mlx_array* res,
@@ -105,7 +111,7 @@ int mlx_fft_irfft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s);
 int mlx_fft_irfftn(
     mlx_array* res,
@@ -114,14 +120,14 @@ int mlx_fft_irfftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s);
 int mlx_fft_rfft(
     mlx_array* res,
     const mlx_array a,
     int n,
     int axis,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s);
 int mlx_fft_rfft2(
     mlx_array* res,
@@ -130,7 +136,7 @@ int mlx_fft_rfft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s);
 int mlx_fft_rfftfreq(mlx_array* res, int n, double d, const mlx_stream s);
 int mlx_fft_rfftn(
@@ -140,8 +146,10 @@ int mlx_fft_rfftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
-    mlx_f_f_t_norm norm,
+    mlx_fft_norm norm,
     const mlx_stream s);
+
+/**@}*/
 
 #ifdef __cplusplus
 }

--- a/mlx/c/fft.h
+++ b/mlx/c/fft.h
@@ -23,16 +23,17 @@
 extern "C" {
 #endif
 
-/**
- * \defgroup fft FFT operations
- */
-/**@{*/
-
+typedef enum mlx_f_f_t_norm_ {
+  MLX_F_F_T_NORM_BACKWARD,
+  MLX_F_F_T_NORM_ORTHO,
+  MLX_F_F_T_NORM_FORWARD
+} mlx_f_f_t_norm;
 int mlx_fft_fft(
     mlx_array* res,
     const mlx_array a,
     int n,
     int axis,
+    mlx_f_f_t_norm norm,
     const mlx_stream s);
 int mlx_fft_fft2(
     mlx_array* res,
@@ -41,7 +42,9 @@ int mlx_fft_fft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s);
+int mlx_fft_fftfreq(mlx_array* res, int n, double d, const mlx_stream s);
 int mlx_fft_fftn(
     mlx_array* res,
     const mlx_array a,
@@ -49,6 +52,7 @@ int mlx_fft_fftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s);
 int mlx_fft_fftshift(
     mlx_array* res,
@@ -61,6 +65,7 @@ int mlx_fft_ifft(
     const mlx_array a,
     int n,
     int axis,
+    mlx_f_f_t_norm norm,
     const mlx_stream s);
 int mlx_fft_ifft2(
     mlx_array* res,
@@ -69,6 +74,7 @@ int mlx_fft_ifft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s);
 int mlx_fft_ifftn(
     mlx_array* res,
@@ -77,6 +83,7 @@ int mlx_fft_ifftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s);
 int mlx_fft_ifftshift(
     mlx_array* res,
@@ -89,6 +96,7 @@ int mlx_fft_irfft(
     const mlx_array a,
     int n,
     int axis,
+    mlx_f_f_t_norm norm,
     const mlx_stream s);
 int mlx_fft_irfft2(
     mlx_array* res,
@@ -97,6 +105,7 @@ int mlx_fft_irfft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s);
 int mlx_fft_irfftn(
     mlx_array* res,
@@ -105,12 +114,14 @@ int mlx_fft_irfftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s);
 int mlx_fft_rfft(
     mlx_array* res,
     const mlx_array a,
     int n,
     int axis,
+    mlx_f_f_t_norm norm,
     const mlx_stream s);
 int mlx_fft_rfft2(
     mlx_array* res,
@@ -119,7 +130,9 @@ int mlx_fft_rfft2(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s);
+int mlx_fft_rfftfreq(mlx_array* res, int n, double d, const mlx_stream s);
 int mlx_fft_rfftn(
     mlx_array* res,
     const mlx_array a,
@@ -127,9 +140,8 @@ int mlx_fft_rfftn(
     size_t n_num,
     const int* axes,
     size_t axes_num,
+    mlx_f_f_t_norm norm,
     const mlx_stream s);
-
-/**@}*/
 
 #ifdef __cplusplus
 }

--- a/mlx/c/ops.cpp
+++ b/mlx/c/ops.cpp
@@ -3221,6 +3221,114 @@ extern "C" int mlx_slice_update_dynamic(
   }
   return 0;
 }
+extern "C" int mlx_slice_update_add(
+    mlx_array* res,
+    const mlx_array src,
+    const mlx_array update,
+    const int* start,
+    size_t start_num,
+    const int* stop,
+    size_t stop_num,
+    const int* strides,
+    size_t strides_num,
+    const mlx_stream s) {
+  try {
+    mlx_array_set_(
+        *res,
+        mlx::core::slice_update_add(
+            mlx_array_get_(src),
+            mlx_array_get_(update),
+            mlx::core::Shape(start, start + start_num),
+            mlx::core::Shape(stop, stop + stop_num),
+            mlx::core::Shape(strides, strides + strides_num),
+            mlx_stream_get_(s)));
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
+extern "C" int mlx_slice_update_max(
+    mlx_array* res,
+    const mlx_array src,
+    const mlx_array update,
+    const int* start,
+    size_t start_num,
+    const int* stop,
+    size_t stop_num,
+    const int* strides,
+    size_t strides_num,
+    const mlx_stream s) {
+  try {
+    mlx_array_set_(
+        *res,
+        mlx::core::slice_update_max(
+            mlx_array_get_(src),
+            mlx_array_get_(update),
+            mlx::core::Shape(start, start + start_num),
+            mlx::core::Shape(stop, stop + stop_num),
+            mlx::core::Shape(strides, strides + strides_num),
+            mlx_stream_get_(s)));
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
+extern "C" int mlx_slice_update_min(
+    mlx_array* res,
+    const mlx_array src,
+    const mlx_array update,
+    const int* start,
+    size_t start_num,
+    const int* stop,
+    size_t stop_num,
+    const int* strides,
+    size_t strides_num,
+    const mlx_stream s) {
+  try {
+    mlx_array_set_(
+        *res,
+        mlx::core::slice_update_min(
+            mlx_array_get_(src),
+            mlx_array_get_(update),
+            mlx::core::Shape(start, start + start_num),
+            mlx::core::Shape(stop, stop + stop_num),
+            mlx::core::Shape(strides, strides + strides_num),
+            mlx_stream_get_(s)));
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
+extern "C" int mlx_slice_update_prod(
+    mlx_array* res,
+    const mlx_array src,
+    const mlx_array update,
+    const int* start,
+    size_t start_num,
+    const int* stop,
+    size_t stop_num,
+    const int* strides,
+    size_t strides_num,
+    const mlx_stream s) {
+  try {
+    mlx_array_set_(
+        *res,
+        mlx::core::slice_update_prod(
+            mlx_array_get_(src),
+            mlx_array_get_(update),
+            mlx::core::Shape(start, start + start_num),
+            mlx::core::Shape(stop, stop + stop_num),
+            mlx::core::Shape(strides, strides + strides_num),
+            mlx_stream_get_(s)));
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
 extern "C" int mlx_softmax_axes(
     mlx_array* res,
     const mlx_array a,

--- a/mlx/c/ops.h
+++ b/mlx/c/ops.h
@@ -1004,6 +1004,50 @@ int mlx_slice_update_dynamic(
     const int* axes,
     size_t axes_num,
     const mlx_stream s);
+int mlx_slice_update_add(
+    mlx_array* res,
+    const mlx_array src,
+    const mlx_array update,
+    const int* start,
+    size_t start_num,
+    const int* stop,
+    size_t stop_num,
+    const int* strides,
+    size_t strides_num,
+    const mlx_stream s);
+int mlx_slice_update_max(
+    mlx_array* res,
+    const mlx_array src,
+    const mlx_array update,
+    const int* start,
+    size_t start_num,
+    const int* stop,
+    size_t stop_num,
+    const int* strides,
+    size_t strides_num,
+    const mlx_stream s);
+int mlx_slice_update_min(
+    mlx_array* res,
+    const mlx_array src,
+    const mlx_array update,
+    const int* start,
+    size_t start_num,
+    const int* stop,
+    size_t stop_num,
+    const int* strides,
+    size_t strides_num,
+    const mlx_stream s);
+int mlx_slice_update_prod(
+    mlx_array* res,
+    const mlx_array src,
+    const mlx_array update,
+    const int* start,
+    size_t start_num,
+    const int* stop,
+    size_t stop_num,
+    const int* strides,
+    size_t strides_num,
+    const mlx_stream s);
 int mlx_softmax_axes(
     mlx_array* res,
     const mlx_array a,

--- a/mlx/c/private/enums.h
+++ b/mlx/c/private/enums.h
@@ -5,6 +5,7 @@
 
 #include "mlx/c/array.h"
 #include "mlx/c/compile.h"
+#include "mlx/c/fft.h"
 #include "mlx/mlx.h"
 
 namespace {
@@ -72,6 +73,18 @@ inline mlx::core::Device::DeviceType mlx_device_type_to_cpp(
   static mlx::core::Device::DeviceType map[] = {
       mlx::core::Device::DeviceType::cpu, mlx::core::Device::DeviceType::gpu};
   return map[(int)type];
+}
+inline mlx_fft_norm mlx_fft_norm_to_c(mlx::core::fft::FFTNorm norm) {
+  static mlx_fft_norm map[] = {
+      MLX_FFT_NORM_BACKWARD, MLX_FFT_NORM_ORTHO, MLX_FFT_NORM_FORWARD};
+  return map[(int)norm];
+}
+inline mlx::core::fft::FFTNorm mlx_fft_norm_to_cpp(mlx_fft_norm norm) {
+  static mlx::core::fft::FFTNorm map[] = {
+      mlx::core::fft::FFTNorm::Backward,
+      mlx::core::fft::FFTNorm::Ortho,
+      mlx::core::fft::FFTNorm::Forward};
+  return map[(int)norm];
 }
 } // namespace
 

--- a/python/c.py
+++ b/python/c.py
@@ -9,7 +9,9 @@ import mlxvariants as variants
 
 
 def to_snake_letters(name):
-    name = re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+    name = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", name)
+    name = re.sub(r"([a-z\d])([A-Z])", r"\1_\2", name)
+    name = name.lower()
     return name
 
 
@@ -123,6 +125,7 @@ extern "C" {
             decl.append(c_typename)
             decl.append(";")
             print(" ".join(decl))
+            print()
 
     for f in sorted_funcs:
         if "variant" in f:

--- a/python/mlxtypes.py
+++ b/python/mlxtypes.py
@@ -418,6 +418,26 @@ types.append(
 
 types.append(
     {
+        "cpp": "mlx::core::fft::FFTNorm",
+        "alt": "FFTNorm",
+        "c": "mlx_f_f_t_norm",
+        "c_to_cpp": lambda s: "static_cast<mlx::core::fft::FFTNorm>(" + s + ")",
+        "c_arg": lambda s, untyped=False: s if untyped else "mlx_f_f_t_norm " + s,
+        "c_return_arg": lambda s, untyped=False: (
+            s if untyped else "mlx_f_f_t_norm* " + s
+        ),
+        "c_new": lambda s: "mlx_f_f_t_norm " + s,
+        "free": lambda s: "",
+        "c_assign_from_cpp": lambda d, s: d
+        + " = "
+        + "static_cast<mlx_f_f_t_norm>(static_cast<int>("
+        + s
+        + "))",
+    }
+)
+
+types.append(
+    {
         "cpp": "std::string",
         "alt": "std::string",
         "c_to_cpp": lambda s: "std::string(" + s + ")",

--- a/python/mlxtypes.py
+++ b/python/mlxtypes.py
@@ -420,19 +420,15 @@ types.append(
     {
         "cpp": "mlx::core::fft::FFTNorm",
         "alt": "FFTNorm",
-        "c": "mlx_f_f_t_norm",
-        "c_to_cpp": lambda s: "static_cast<mlx::core::fft::FFTNorm>(" + s + ")",
-        "c_arg": lambda s, untyped=False: s if untyped else "mlx_f_f_t_norm " + s,
+        "c": "mlx_fft_norm",
+        "c_to_cpp": lambda s: "mlx_fft_norm_to_cpp(" + s + ")",
+        "c_arg": lambda s, untyped=False: s if untyped else "mlx_fft_norm " + s,
         "c_return_arg": lambda s, untyped=False: (
-            s if untyped else "mlx_f_f_t_norm* " + s
+            s if untyped else "mlx_fft_norm* " + s
         ),
-        "c_new": lambda s: "mlx_f_f_t_norm " + s,
+        "c_new": lambda s: "mlx_fft_norm " + s,
         "free": lambda s: "",
-        "c_assign_from_cpp": lambda d, s: d
-        + " = "
-        + "static_cast<mlx_f_f_t_norm>(static_cast<int>("
-        + s
-        + "))",
+        "c_assign_from_cpp": lambda d, s: d + " = " + "mlx_fft_norm_to_c(" + s + ")",
     }
 )
 


### PR DESCRIPTION
This updates mlx-c for MLX 0.31.2 API changes.

- manually updated type mappings in `python/mlxtypes.py` (for `FFTNorm`)
- ran the autogeneration script for updated bindings (notably `fft` and `ops`)
- keeps existing wrappers (including `einsum` and compile detail wrappers) while adding new generated wrappers
- bumped vendored MLX tag in `CMakeLists.txt` to `v0.31.2`

PS: I only use an llm for running the autogen commands and compare the mlx changelogs 
