### PR TITLE
Add mlx_metal_set_metallib_path() C API

### DIFF
--- a/mlx/c/metal.cpp
+++ b/mlx/c/metal.cpp
@@ -17,6 +17,15 @@ extern "C" int mlx_metal_is_available(bool* res) {
   }
   return 0;
 }
+extern "C" int mlx_metal_set_metallib_path(const char* path) {
+  try {
+    mlx::core::metal::set_metallib_path(std::string(path));
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
 extern "C" int mlx_metal_start_capture(const char* path) {
   try {
     mlx::core::metal::start_capture(std::string(path));

--- a/mlx/c/metal.h
+++ b/mlx/c/metal.h
@@ -29,6 +29,7 @@ extern "C" {
 /**@{*/
 
 int mlx_metal_is_available(bool* res);
+int mlx_metal_set_metallib_path(const char* path);
 int mlx_metal_start_capture(const char* path);
 int mlx_metal_stop_capture(void);
 


### PR DESCRIPTION
## What

Exposes the new `mlx::core::metal::set_metallib_path()` through the C interface as `mlx_metal_set_metallib_path(const char* path)`, following the existing error-handling convention of the other `mlx_metal_*` wrappers.

## Why

Required so Swift / other C consumers can set a custom `mlx.metallib` path. See the use case in the tracking issue.

## Depends on

- ml-explore/mlx#3597 (the underlying C++ function). The `mlx` submodule here will need a bump to the merged commit once that lands.

## Companion PRs

Part of a three-PR chain (C++ → C → Swift):

1. ml-explore/mlx#3597 — C++ `set_metallib_path`
2. **ml-explore/mlx-c#117** — this PR (C API wrapper)
3. ml-explore/mlx-swift#416 — Swift `GPU.setMetallibPath()`

Tracking issue: ml-explore/mlx-swift#415.
