### PR TITLE
Add mlx_array_detach to break graph links before free

### DIFF
--- a/mlx/c/array.cpp
+++ b/mlx/c/array.cpp
@@ -34,6 +34,18 @@ extern "C" int mlx_array_free(mlx_array arr) {
   return 0;
 }
 
+extern "C" int mlx_array_detach(mlx_array arr) {
+  try {
+    if (arr.ctx) {
+      static_cast<mlx::core::array*>(arr.ctx)->detach();
+    }
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
+
 extern "C" mlx_array mlx_array_new(void) {
   try {
     return mlx_array_();

--- a/mlx/c/array.h
+++ b/mlx/c/array.h
@@ -82,6 +82,16 @@ mlx_array mlx_array_new(void);
 int mlx_array_free(mlx_array arr);
 
 /**
+ * Detach an array from the MLX computation graph.
+ *
+ * Clears sibling links so the array can be freed without leaving dangling
+ * references in shared ArrayDesc nodes. Call before mlx_array_free when
+ * releasing model weights or other arrays that may still be linked in the
+ * graph.
+ */
+int mlx_array_detach(mlx_array arr);
+
+/**
  * New array from a bool scalar.
  */
 mlx_array mlx_array_new_bool(bool val);


### PR DESCRIPTION
## Summary

Adds `mlx_array_detach()` to the C API, wrapping the existing `mlx::core::array::detach()` method.

When releasing model weights or other arrays that may still be linked in the computation graph (e.g. sibling outputs from a traced/compiled forward pass), calling `mlx_array_free()` alone can leave dangling references in shared `ArrayDesc` nodes. Detaching first clears those sibling links so the buffer can be freed safely.

- Declares `mlx_array_detach` in `mlx/c/array.h` with documentation
- Implements a thin wrapper in `mlx/c/array.cpp`
- No-op when `arr.ctx` is null, consistent with `mlx_array_free_`

## Motivation

Downstream bindings (Go via dynamic `libmlxc`, Swift, etc.) that hold weight arrays across inference sessions currently need to patch `array.cpp` locally or call into C++ internals to detach before free. Exposing this in the public C API removes that friction.

## Test plan

- [ ] Build mlx-c against MLX v0.31.2
- [ ] Verify `mlx_array_detach` is exported from `libmlxc`
- [ ] Manual: create an array via ops, detach, free — no crash
- [ ] Manual: detach + free weight arrays after a compiled forward pass — no use-after-free