### PR TITLE
Bind new_thread_unsafe_stream

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,3 +26,9 @@ target_link_libraries(example-gguf PUBLIC mlxc)
 
 add_executable(example-graph ${CMAKE_CURRENT_LIST_DIR}/example-graph.c)
 target_link_libraries(example-graph PUBLIC mlxc)
+
+add_executable(example-thread-stream
+               ${CMAKE_CURRENT_LIST_DIR}/example-thread-stream.c)
+target_link_libraries(example-thread-stream PUBLIC mlxc)
+find_package(Threads REQUIRED)
+target_link_libraries(example-thread-stream PUBLIC Threads::Threads)

--- a/examples/example-thread-stream.c
+++ b/examples/example-thread-stream.c
@@ -1,0 +1,73 @@
+/* Copyright © 2025 Apple Inc. */
+
+/* Streams are thread affine: a stream created on one thread cannot be used to
+ * evaluate on another. `mlx_stream_new_thread_unsafe` opts out of that, which
+ * is what language bindings that do their own locking need.
+ *
+ * This creates a stream on the main thread and evaluates on it from a worker
+ * thread. Note the mutex: MLX applies no synchronization to these streams, so
+ * serializing the work is the caller's job.
+ */
+
+#include <pthread.h>
+#include <stdio.h>
+
+#include "mlx/c/mlx.h"
+
+static pthread_mutex_t eval_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+typedef struct {
+  mlx_stream stream;
+  float result;
+  int status;
+} work;
+
+static void* run(void* arg) {
+  work* w = (work*)arg;
+
+  pthread_mutex_lock(&eval_mutex);
+
+  mlx_array a = mlx_array_new_float(2.0);
+  mlx_array b = mlx_array_new_float(3.0);
+  mlx_array sum = mlx_array_new();
+
+  w->status = mlx_add(&sum, a, b, w->stream);
+  if (w->status == 0) {
+    w->status = mlx_array_item_float32(&w->result, sum);
+  }
+
+  mlx_array_free(a);
+  mlx_array_free(b);
+  mlx_array_free(sum);
+
+  pthread_mutex_unlock(&eval_mutex);
+  return NULL;
+}
+
+int main(void) {
+  mlx_device dev = mlx_device_new();
+  mlx_get_default_device(&dev);
+
+  /* created here, used on the worker thread below */
+  work w = {mlx_stream_new_thread_unsafe(dev), 0.0f, 0};
+
+  pthread_t thread;
+  if (pthread_create(&thread, NULL, run, &w) != 0) {
+    printf("failed to spawn thread\n");
+    return 1;
+  }
+  pthread_join(thread, NULL);
+
+  if (w.status != 0) {
+    /* the default error handler has already reported the reason */
+    printf("evaluation failed\n");
+    return 1;
+  }
+
+  printf("2 + 3 evaluated on another thread = %g\n", w.result);
+
+  mlx_stream_free(w.stream);
+  mlx_device_free(dev);
+
+  return 0;
+}

--- a/mlx/c/stream.cpp
+++ b/mlx/c/stream.cpp
@@ -32,6 +32,15 @@ extern "C" mlx_stream mlx_stream_new_device(mlx_device dev) {
     return mlx_stream_new_();
   }
 }
+extern "C" mlx_stream mlx_stream_new_thread_unsafe(mlx_device dev) {
+  try {
+    return mlx_stream_new_(
+        mlx::core::new_thread_unsafe_stream(mlx_device_get_(dev)));
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return mlx_stream_new_();
+  }
+}
 extern "C" int mlx_stream_set(mlx_stream* stream, const mlx_stream src) {
   try {
     mlx_stream_set_(*stream, mlx_stream_get_(src));

--- a/mlx/c/stream.h
+++ b/mlx/c/stream.h
@@ -34,6 +34,18 @@ mlx_stream mlx_stream_new(void);
  */
 mlx_stream mlx_stream_new_device(mlx_device dev);
 /**
+ * Returns a new stream on a device that can be used from any thread.
+ *
+ * Streams are otherwise thread affine: a stream's GPU command encoder is
+ * registered per thread, so evaluating on a stream from a thread other than
+ * the one that created it fails. Streams returned here are registered
+ * globally instead.
+ *
+ * MLX applies no synchronization to these streams -- it is the caller's
+ * responsibility to ensure there are no data races on them.
+ */
+mlx_stream mlx_stream_new_thread_unsafe(mlx_device dev);
+/**
  * Set stream to provided src stream.
  */
 int mlx_stream_set(mlx_stream* stream, const mlx_stream src);


### PR DESCRIPTION
## Summary

Expose mlx's `new_thread_unsafe_stream` as `mlx_stream_new_thread_unsafe`.

Streams became thread affine in mlx 0.31.2 ([#3348](https://github.com/ml-explore/mlx/pull/3348), [#3281](https://github.com/ml-explore/mlx/pull/3281)): a stream's GPU command encoder is registered in a `thread_local` map, so evaluating on a stream from a thread other than the one that created it raises `There is no Stream(gpu, N) in current thread.`

mlx added `new_thread_unsafe_stream` in [ml-explore/mlx#3578](https://github.com/ml-explore/mlx/pull/3578) specifically for this case:

> This provides a way for language bindings (like Swift) to evaluate graph asynchronously via threads, on the condition that they add locks on themselves.

mlx-c does not bind it, so those bindings can't reach it. mlx-swift currently carries a local C shim to work around exactly this, which this PR would let it delete.

## Before / after

`examples/example-thread-stream.c` creates a stream on the main thread and evaluates on it from a worker thread. With `mlx_stream_new_device`:

```
MLX error: There is no Stream(gpu, 0) in current thread. at mlx/c/array.cpp:443
```

With `mlx_stream_new_thread_unsafe`:

```
2 + 3 evaluated on another thread = 5
```

## Note on the mlx pin

`new_thread_unsafe_stream` only exists in mlx 0.32.0, so `GIT_TAG` moves from `v0.31.2` to `v0.32.0`. I kept that to the one-line bump rather than regenerating bindings for 0.32.0, on the assumption you'd rather do that as its own change — happy to drop the bump if you'd prefer to land this after a 0.32.0 regen.

The existing bindings compile unchanged against 0.32.0, and `example`, `example-grad`, `example-closure`, `example-graph` and `example-export` all pass.

## Naming

I went with `mlx_stream_new_thread_unsafe` to sit alongside `mlx_stream_new_device` in the `mlx_stream_new*` constructor family. Happy to rename to `mlx_new_thread_unsafe_stream` (closer to the C++ name) or anything else you prefer.

## Possible follow-up

`new_thread_local_stream` / `stream_from_thread_local_stream` / `clear_streams` are also unbound. They need a new opaque `mlx_thread_local_stream` type with its own private accessors, so I left them out to keep this focused — glad to do it in a separate PR if it's wanted.

## Checklist

- [x] Formatted with `clang-format` using the repo's `.clang-format`
- [x] Added an example exercising the new API
- [x] Built and ran locally (macOS 27.0, Apple Silicon)
