### PR TITLE
Add mlx_conv2d_bias_silu binding

### DIFF
--- a/mlx/c/ops.cpp
+++ b/mlx/c/ops.cpp
@@ -776,6 +776,37 @@ extern "C" int mlx_conv2d(
   }
   return 0;
 }
+extern "C" int mlx_conv2d_bias_silu(
+    mlx_array* res,
+    const mlx_array input,
+    const mlx_array weight,
+    const mlx_array bias,
+    int stride_0,
+    int stride_1,
+    int padding_0,
+    int padding_1,
+    int dilation_0,
+    int dilation_1,
+    int groups,
+    const mlx_stream s) {
+  try {
+    mlx_array_set_(
+        *res,
+        mlx::core::conv2d_bias_silu(
+            mlx_array_get_(input),
+            mlx_array_get_(weight),
+            mlx_array_get_(bias),
+            std::make_pair(stride_0, stride_1),
+            std::make_pair(padding_0, padding_1),
+            std::make_pair(dilation_0, dilation_1),
+            groups,
+            mlx_stream_get_(s)));
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
 extern "C" int mlx_conv3d(
     mlx_array* res,
     const mlx_array input,

--- a/mlx/c/ops.h
+++ b/mlx/c/ops.h
@@ -246,6 +246,19 @@ int mlx_conv2d(
     int dilation_1,
     int groups,
     const mlx_stream s);
+int mlx_conv2d_bias_silu(
+    mlx_array* res,
+    const mlx_array input,
+    const mlx_array weight,
+    const mlx_array bias,
+    int stride_0,
+    int stride_1,
+    int padding_0,
+    int padding_1,
+    int dilation_0,
+    int dilation_1,
+    int groups,
+    const mlx_stream s);
 int mlx_conv3d(
     mlx_array* res,
     const mlx_array input,


### PR DESCRIPTION
Hey folks - I'm building a YOLO (v9) lib using MLX-Swift targeting CUDA and Apple Silicon.

Ran into some performance gaps that were not too hard to address. This is one part of it.

## Summary

Adds a C binding `mlx_conv2d_bias_silu` for the fused conv+bias+SiLU op. Pure addition to `mlx/c/ops.h` / `mlx/c/ops.cpp` — it wraps `mlx::core::conv2d_bias_silu(input, weight, bias, stride, padding, dilation, groups, stream)`.

## Depends on

This binds a symbol that does not yet exist in `mlx::core` — it **depends on** the fused-conv PR upstream in `ml-explore/mlx`:

- ml-explore/mlx#4307 — `[CUDA] Fused conv+bias+SiLU epilogue`

It will not build against MLX until that PR (or an equivalent `conv2d_bias_silu` op) lands. Merging should wait on it.
