### PR TITLE
Propagate IO errors from custom readers and writers

### DIFF
--- a/mlx/c/private/io.h
+++ b/mlx/c/private/io.h
@@ -2,6 +2,7 @@
 #define MLX_IO_PRIVATE_H
 
 #include <iostream>
+#include <sstream>
 #include <streambuf>
 
 #include "mlx/mlx.h"
@@ -41,16 +42,30 @@ class CReader : public mlx::core::io::Reader {
     }
   }
   virtual void read(char* data, size_t n) override {
-    return vtable.read(desc, data, n);
+    vtable.read(desc, data, n);
+    check_read_(n);
   };
   virtual void read(char* data, size_t n, size_t offset) override {
-    return vtable.read_at_offset(desc, data, n, offset);
+    vtable.read_at_offset(desc, data, n, offset);
+    check_read_(n);
   };
   virtual std::string label() const override {
     return vtable.label(desc);
   };
   virtual ~CReader() {
     vtable.free(desc);
+  }
+
+ private:
+  // The read functions of the vtable have no return value, so a failed read is
+  // only reported through good(). Turn it into an exception, as done by the
+  // readers implemented in mlx, so the error can propagate to the caller.
+  void check_read_(size_t n) {
+    if (!vtable.good(desc)) {
+      std::ostringstream msg;
+      msg << "[read] Unable to read " << n << " bytes from " << label() << ".";
+      throw std::runtime_error(msg.str());
+    }
   }
 };
 
@@ -87,7 +102,13 @@ class CWriter : public mlx::core::io::Writer {
     }
   }
   virtual void write(const char* data, size_t n) override {
-    return vtable.write(desc, data, n);
+    vtable.write(desc, data, n);
+    // Same as CReader::read(): a failed write is only reported through good().
+    if (!vtable.good(desc)) {
+      std::ostringstream msg;
+      msg << "[write] Unable to write " << n << " bytes to " << label() << ".";
+      throw std::runtime_error(msg.str());
+    }
   };
   virtual std::string label() const override {
     return vtable.label(desc);


### PR DESCRIPTION
 
• The  mlx_io_vtable  read/write callbacks return  void , so  good()  is the only error channel and  CReader / CWriter  never checked it, so failures were silently dropped and the caller got garbage data.
• Now mirrors  mlx::core::io::ParallelFileReader::read  /  FileWriter::write , which already throw on short reads/writes.

## Motivation

This is the missing first link for ml-explore/mlx#3742. With that fix, an exception from  Load::eval_cpu 's read task poisons the stream's events and is re-thrown at eval time but only mlx's own file reader ever threw. Custom readers (e.g. mlx-swift's, see ml-explore/mlx-swift#427) could not report a truncated/failed read at all.
