### PR TITLE
Adds mlx_get_array_buffer_size API from core mlx

### DIFF
--- a/mlx/c/memory.cpp
+++ b/mlx/c/memory.cpp
@@ -26,6 +26,17 @@ extern "C" int mlx_get_active_memory(size_t* res) {
   }
   return 0;
 }
+extern "C" int mlx_get_array_buffer_size(
+    size_t* res,
+    const mlx_vector_array arrays) {
+  try {
+    *res = mlx::core::get_array_buffer_size(mlx_vector_array_get_(arrays));
+  } catch (std::exception& e) {
+    mlx_error(e.what());
+    return 1;
+  }
+  return 0;
+}
 extern "C" int mlx_get_cache_memory(size_t* res) {
   try {
     *res = mlx::core::get_cache_memory();

--- a/mlx/c/memory.h
+++ b/mlx/c/memory.h
@@ -30,6 +30,7 @@ extern "C" {
 
 int mlx_clear_cache(void);
 int mlx_get_active_memory(size_t* res);
+int mlx_get_array_buffer_size(size_t* res, const mlx_vector_array arrays);
 int mlx_get_cache_memory(size_t* res);
 int mlx_get_memory_limit(size_t* res);
 int mlx_get_peak_memory(size_t* res);


### PR DESCRIPTION
After my PR https://github.com/ml-explore/mlx/pull/4436 has been merged, we can proceed to include it here once a new release of MLX will be tagged. 